### PR TITLE
allow specifying filelist to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     # branch = "beta_name";
     # Enable debug logging from DepotDownloader.
     # debug = true;
+    # Only download specific files
+    # fileList = ["filename" "regex:(or|a|regex)"];
     hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
   };
 

--- a/fetch-steam/builder.sh
+++ b/fetch-steam/builder.sh
@@ -22,6 +22,10 @@ if [ -n "$debug" ]; then
 	args+=(-debug)
 fi
 
+if [ -n "$filelist" ]; then
+	args+=(-filelist "$filelist")
+fi
+
 DepotDownloader \
 	"${args[@]}" \
 	-dir "${out:?}"

--- a/fetch-steam/default.nix
+++ b/fetch-steam/default.nix
@@ -3,6 +3,7 @@
   stdenvNoCC,
   depotdownloader,
   cacert,
+  writeText,
 }: {
   name,
   debug ? false,
@@ -10,18 +11,28 @@
   depotId,
   manifestId,
   branch ? null,
+  fileList ? [],
   hash,
-}:
-stdenvNoCC.mkDerivation {
-  name = "${name}-depot";
-  inherit debug appId depotId manifestId branch;
-  builder = ./builder.sh;
-  buildInputs = [
-    depotdownloader
-  ];
-  SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
+}: let
+  fileListFile = let
+    content = lib.concatStringsSep "\n" fileList;
+  in
+    writeText "steam-file-list-${name}.txt" content;
+in
+  stdenvNoCC.mkDerivation {
+    name = "${name}-depot";
+    inherit debug appId depotId manifestId branch;
+    filelist =
+      if fileList != []
+      then fileListFile
+      else null;
+    builder = ./builder.sh;
+    buildInputs = [
+      depotdownloader
+    ];
+    SSL_CERT_FILE = "${cacert}/etc/ssl/certs/ca-bundle.crt";
 
-  outputHash = hash;
-  outputHashAlgo = "sha256";
-  outputHashMode = "recursive";
-}
+    outputHash = hash;
+    outputHashAlgo = "sha256";
+    outputHashMode = "recursive";
+  }


### PR DESCRIPTION
Allow downloading only specific files from the depot using the `-filelist` option.