### PR TITLE
fix: pin depotdownloader to inputs.nixpkgs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -65,9 +65,17 @@
         '';
       });
 
-    overlays.default = final: prev: {
-      fetchSteam = final.callPackage ./fetch-steam {};
+    overlays.default = final: prev: let
+      pkgs = pkgsFor final.system;
+    in rec {
+      fetchSteam = final.callPackage ./fetch-steam {inherit (pkgs) depotdownloader;};
       steamworks-sdk-redist = final.callPackage ./steamworks-sdk-redist {};
     };
+
+    packages = forAllSystems (system: let
+      pkgs = pkgsFor system;
+    in rec {
+      inherit (pkgs) steamworks-sdk-redist;
+    });
   };
 }


### PR DESCRIPTION
I based this on the idea from https://github.com/nix-community/steam-fetcher/tree/fetch-hash-issue

It pins depotdownloader this flakes nixpkgs input, even in the overlays.

